### PR TITLE
Fix ambiguous call to `constraints.as_ref()`

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -57,7 +57,7 @@ pub fn create_layout(app: &App, frame: &mut Frame<CrosstermBackend<Stdout>>) -> 
         .direction(Direction::Horizontal)
         .margin(1)
         .horizontal_margin(0)
-        .constraints(constraints.as_ref())
+        .constraints(constraints.as_slice())
         .split(base_chunk[1]);
 
     AppLayout {


### PR DESCRIPTION
If `fast-ssh` is built with an up-to-date version of `rustc`, the compiler complains about `constraints.as_ref()` being ambiguous, demanding the types involved in the `.constraints()` call be clarified with a `::<&[Constraint]>` turbofish annotation. Calling `constraints.as_slice()` instead removes the ambiguity.

As an example, see this failing Nixpkgs build: https://hydra.nixos.org/build/243071074
Log: https://hydra.nixos.org/build/243071074/nixlog/4

Reproduced locally with a current rust version:

```
[nix-shell:~/source/fast-ssh]$ cargo build
   Compiling fast-ssh v0.3.1 (/home/manuel/source/fast-ssh)
error[E0283]: type annotations needed
  --> src/layout.rs:60:10
   |
60 |         .constraints(constraints.as_ref())
   |          ^^^^^^^^^^^             ------ type must be known at this point
   |          |
   |          cannot infer type of the type parameter `C` declared on the method `constraints`
   |
   = note: multiple `impl`s satisfying `Vec<Constraint>: AsRef<_>` found in the `alloc` crate:
           - impl<T, A> AsRef<Vec<T, A>> for Vec<T, A>
             where A: Allocator;
           - impl<T, A> AsRef<[T]> for Vec<T, A>
             where A: Allocator;
help: consider specifying the generic argument
   |
60 |         .constraints::<&T>(constraints.as_ref())
   |                     ++++++

For more information about this error, try `rustc --explain E0283`.
error: could not compile `fast-ssh` (bin "fast-ssh") due to previous error

[nix-shell:~/source/fast-ssh]$ cargo --version
cargo 1.74.1 (ecb9851af 2023-10-18)

nix-shell:~/source/fast-ssh]$ rustc --version
rustc 1.74.1 (a28077b28 2023-12-04)
```