### PR TITLE
Always have the selected group be the first one in the list

### DIFF
--- a/src/widgets/groups_widget.rs
+++ b/src/widgets/groups_widget.rs
@@ -12,7 +12,8 @@ pub struct GroupsWidget {}
 impl GroupsWidget {
     pub fn render(app: &App, area: Rect, frame: &mut Frame<CrosstermBackend<Stdout>>) {
         let block = block::new(" Groups ");
-        let titles = app
+
+        let mut titles: Vec<Spans> = app
             .scs
             .groups
             .iter()
@@ -24,9 +25,13 @@ impl GroupsWidget {
             })
             .collect();
 
+        if app.selected_group < titles.len() {
+            titles.rotate_left(app.selected_group);
+        }
+
         let tabs = Tabs::new(titles)
             .block(block)
-            .select(app.selected_group)
+            .select(0)
             .highlight_style(
                 Style::default()
                     .add_modifier(Modifier::BOLD)


### PR DESCRIPTION
Just started using fast-ssh. One of the first thing that I had noticed after adding my ssh config file was that when we have more groups that what is able to be shown on screen the group selection does not move with the cursor.

This is an attempt to remedy that.

The selected group is always placed first so that we can always see what group we are in when we have many groups.