### PR TITLE
Fix host selection in different size host lists

### DIFF
--- a/src/widgets/hosts_widget.rs
+++ b/src/widgets/hosts_widget.rs
@@ -19,7 +19,12 @@ impl HostsWidget {
     pub fn render(app: &mut App, area: Rect, frame: &mut Frame<CrosstermBackend<Stdout>>) {
         let block = block::new(" Hosts ");
         let header = HostsWidget::create_header();
-        let rows = HostsWidget::create_rows_from_items(&app.get_items_based_on_mode());
+        let items = app.get_items_based_on_mode();
+        let rows = HostsWidget::create_rows_from_items(&items);
+
+        if app.host_state.selected().unwrap_or(0) >= items.len() {
+            app.host_state.select(Some(0));
+        }
 
         let t = Table::new(rows)
             .header(header)


### PR DESCRIPTION
When going from a list of say 4 items and switching to a group that has only 2 items in it I noticed that the next group selection would be lost.

Current selection method:
```
Group 1
---
host1
host2
host3
-> host4
```
*SWITCH TO GROUP 2*
```
Group 2
---
host1
host2
```

Pull Request selection method:
```
Group 1
---
host1
host2
host3
-> host4
```
*SWITCH TO GROUP 2*
```
Group 2
---
-> host1
host2
```

'host1' in 'Group 2' is now selected when we switch to that group.

