### PR TITLE
Add the ability to display notes with comments

### DIFF
--- a/src/ssh_config_store.rs
+++ b/src/ssh_config_store.rs
@@ -2,6 +2,45 @@ use crate::database::FileDatabase;
 use anyhow::{format_err, Result};
 use ssh_cfg::{SshConfig, SshConfigParser, SshHostConfig};
 use std::fmt::Debug;
+use std::collections::HashMap;
+use std::fs::read_to_string;
+use std::path::PathBuf;
+
+trait ConfigComments {
+    fn get_comments(&self) -> HashMap<String, String>;
+}
+
+impl ConfigComments for SshConfig {
+    fn get_comments(&self) -> HashMap<String, String> {
+        let mut comments = HashMap::new();
+
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+        let config_path = PathBuf::from(home).join(".ssh").join("config");
+
+        if let Ok(contents) = read_to_string(config_path) {
+            let mut current_comment = Vec::new();
+
+            for line in contents.lines() {
+                let trimmed = line.trim();
+
+                if trimmed.starts_with('#') {
+                    let comment_text = trimmed[1..].trim().to_string();
+                    current_comment.push(comment_text);
+                } else if trimmed.starts_with("Host ") {
+                    let host = trimmed["Host ".len()..].trim().to_string();
+                    if !current_comment.is_empty() {
+                        comments.insert(host, current_comment.join("\n"));
+                        current_comment.clear();
+                    }
+                } else if trimmed.is_empty() {
+                    current_comment.clear();
+                }
+            }
+        }
+
+        comments
+    }
+}
 
 #[derive(Debug)]
 pub struct SshGroupItem {
@@ -10,6 +49,7 @@ pub struct SshGroupItem {
     pub connection_count: i64,
     pub last_used: i64,
     pub host_config: SshHostConfig,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug)]
@@ -28,12 +68,14 @@ impl SshConfigStore {
     pub async fn new(db: &FileDatabase) -> Result<SshConfigStore> {
         let ssh_config = SshConfigParser::parse_home().await?;
 
+        let comments = ssh_config.get_comments();
+
         let mut scs = SshConfigStore {
             config: ssh_config,
             groups: Vec::new(),
         };
 
-        scs.create_ssh_groups(db);
+        scs.create_ssh_groups(db, &comments);
 
         if scs.groups.is_empty() {
             return Err(format_err!("Your configuration file contains no entries (or only wildcards) ! Please add at least one."));
@@ -42,7 +84,7 @@ impl SshConfigStore {
         Ok(scs)
     }
 
-    fn create_ssh_groups(&mut self, db: &FileDatabase) {
+    fn create_ssh_groups(&mut self, db: &FileDatabase, comments: &std::collections::HashMap<String, String>) {
         let mut groups: Vec<SshGroup> = vec![SshGroup {
             name: "Others".to_string(),
             items: Vec::new(),
@@ -67,6 +109,7 @@ impl SshConfigStore {
                     last_used: host_entry.last_used_date,
                     full_name: key.to_string(),
                     host_config: value.clone(),
+                    comment: comments.get(key).cloned(),
                 };
 
                 if group.is_none() {
@@ -90,6 +133,7 @@ impl SshConfigStore {
                 last_used: host_entry.last_used_date,
                 name: key.to_string(),
                 host_config: value.clone(),
+                comment: comments.get(key).cloned(),
             });
         });
 

--- a/src/widgets/config_widget.rs
+++ b/src/widgets/config_widget.rs
@@ -61,13 +61,15 @@ impl ConfigWidget {
     }
 
     fn ssh_group_item_to_spans(config: &SshGroupItem) -> Vec<Spans> {
-        let mut spans = vec![Spans::from(vec![
+        let mut spans = Vec::new();
+
+        spans.push(Spans::from(vec![
             Span::styled("Host ", Style::default().fg(THEME.text_primary())),
             Span::styled(
                 &config.full_name,
                 Style::default().fg(THEME.text_secondary()),
             ),
-        ])];
+        ]));
 
         config.host_config.iter().for_each(|(key, value)| {
             spans.push(Spans::from(vec![
@@ -77,6 +79,19 @@ impl ConfigWidget {
                 Span::styled(value, Style::default().fg(THEME.text_secondary())),
             ]));
         });
+
+        if let Some(comment) = &config.comment {
+            spans.push(Spans::from(vec![
+                Span::styled("  Notes", Style::default().fg(THEME.text_primary())),
+            ]));
+
+            for line in comment.lines() {
+                spans.push(Spans::from(vec![
+                    Span::styled("    ", Style::default().fg(THEME.text_primary())),
+                    Span::styled(line, Style::default().fg(THEME.text_secondary())),
+                ]));
+            }
+        }
 
         spans.push(Spans::from(vec![Span::styled(
             "\n",


### PR DESCRIPTION
Add the ability to display notes under "Configuration" by adding comments to the SSH Config file.

When using the following config:

```
# - Production Server
# - On Corporate Network
Host Automation Server/server1
    HostName 192.168.1.1
    User user
```

We can see the notes shown as follow:

- ![image](https://github.com/user-attachments/assets/fcf961a1-a2a0-4f40-b2bf-07c61a97a0ee)

Each note for that host will be added as a separate line. You can also add things like * or - to create a bullet point effect to the notes as shown.